### PR TITLE
Remove `-release` from app name for digital marketplace apps

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,4 +1,3 @@
----
 applications:
 - name: metric-exporter
   memory: 100M
@@ -6,3 +5,13 @@ applications:
   buildpack: go_buildpack
   health-check-type: none
   no-route: true
+  env:
+    API_ENDPOINT: https://api.cloud.service.gov.uk
+    STATSD_ENDPOINT: statsd.hostedgraphite.com:8125
+    STATSD_PREFIX: statsd_prefix
+    USERNAME: cloud_foundry_user
+    PASSWORD: cloud_foundry_password
+    SKIP_SSL_VALIDATION: "false"
+    DEBUG: "false"
+    UPDATE_FREQUENCY: "60"
+    METRIC_TEMPLATE: "{{.Space}}.{{.App}}.{{.Instance}}.{{.Metric}}"

--- a/metrics/metric_template.go
+++ b/metrics/metric_template.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"bytes"
 	"text/template"
+	"strings"
 
 	cfclient "github.com/cloudfoundry-community/go-cfclient"
 	"github.com/cloudfoundry/sonde-go/events"
@@ -46,7 +47,7 @@ func (mv *Vars) Compose(providedTemplate string) (string, error) {
 }
 
 func (mv *Vars) Parse(stream *Stream) {
-	mv.App = stream.App.Name
+	mv.App = strings.Replace(stream.App.Name, "-release", "", -1)
 	mv.GUID = stream.App.Guid
 	mv.CellId = stream.Msg.GetIndex()
 	mv.Instance = ""


### PR DESCRIPTION
During our deployment of an application called app, we have a new
application spun up called `app-release`. When this app is happy
we take down the already running `app` and then rename our new app
to replace it.

The new application will begin streaming metrics under the application
name `app-release` but we don't want these shown in our
graphana dashboards so we remove the prefix. Even though the app
is renamed, the metrics appear to stream under the two names
(`app` and `app-release`), alternating after each deployment. It is
not entirely clear why.

This fix is intended to be a short run solution before we talk to
the PaaS team about our issue and come up with a longer term
solution.